### PR TITLE
doc: fix non-compiling examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ httpGet = do
   JSON req <- input
   -- Send the request, get a 'Response'
   res <- sendRequest req (Nothing :: Maybe String)
-  -- Save response body to memory
-  outputMemory (memory res)
+  -- Save response body to output
+  output $ responseData res
   -- Return code
   return 0
 
@@ -243,6 +243,8 @@ to do this correctly. So we recommend reading out [concept doc on Host Functions
 Host functions in the Haskell PDK require C stubs to import a function from a particular namespace:
 
 ```c
+#include <stdint.h>
+
 #define IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
 IMPORT("extism:host/user", "a_python_func")
 uint64_t a_python_func_impl(uint64_t input);
@@ -265,8 +267,9 @@ foreign import ccall "a_python_func" aPythonFunc :: Word64 -> IO Word64
 helloFromPython :: String -> IO String
 helloFromPython = do
   s' <- allocString "Hello!"
-  res <- aPythonFunc (memoryOffset s')
-  logInfo <$> loadString res
+  resOffset <- aPythonFunc (memoryOffset s')
+  resMem <- findMemory resOffset
+  logInfo =<< loadString resMem
   return 0
 
 foreign export ccall "helloFromPython" helloFromPython :: IO Int32


### PR DESCRIPTION
some of these look like they might just be outdated code examples?

other things like `logInfo <$> loadString res` don't really make sense either way, since fmapping there would end up with a nested IO, so I replaced that with a bind.

let me know if I'm missing something or misunderstanding the examples in some way, but to me it looks like this should work better now.